### PR TITLE
Create .gitattributes to manage language

### DIFF
--- a/. gitattributes
+++ b/. gitattributes
@@ -1,0 +1,2 @@
+* linguist-vendored
+*.R linguist-vendored=false


### PR DESCRIPTION
Quick .gitattributes fix to reflect the fact that the core of this analysis was written in R, not HTML. GitHub's [Linguist](https://github.com/github/linguist#troubleshooting) implementation is weighting the number of HTML files currently in this repo more heavily than the R ones @tresmont wrote to do the analysis. See this stackoverflow [example](https://stackoverflow.com/questions/34713765/github-changes-repository-to-wrong-language) and GitHub [Help](https://help.github.com/articles/about-repository-languages/) for more information. 

Granted this is a quick-fix, brute force solution and it might be useful for all of us to think about other ways of working with GitHub's Linguist. Again see the stackoverflow [example](https://stackoverflow.com/questions/34713765/github-changes-repository-to-wrong-language) for more elegant and extensible solutions.